### PR TITLE
feat: Add Game Boy / GBC Build Pipeline (#60)

### DIFF
--- a/src/GameInfoTools.Core/Build/GameBoyAssetExtractor.cs
+++ b/src/GameInfoTools.Core/Build/GameBoyAssetExtractor.cs
@@ -1,0 +1,385 @@
+namespace GameInfoTools.Core.Build;
+
+/// <summary>
+/// Game Boy / Game Boy Color asset extractor with platform-specific handling.
+/// Supports 2bpp tile graphics, palettes, and ROM bank extraction.
+/// </summary>
+public class GameBoyAssetExtractor : IAssetExtractor {
+	/// <summary>
+	/// Extract assets from a Game Boy ROM.
+	/// </summary>
+	public async Task<AssetExtractionResult> ExtractAsync(
+		byte[] romData,
+		AssetDefinition asset,
+		string outputPath,
+		AssetsConfig config,
+		CancellationToken cancellationToken = default) {
+		var result = new AssetExtractionResult();
+
+		try {
+			var parser = new GameBoyRomParser(romData);
+			var romInfo = parser.GetRomInfo();
+
+			// Add ROM info to metadata
+			result.Metadata["title"] = romInfo.Title;
+			result.Metadata["isGameBoyColor"] = romInfo.IsGameBoyColor;
+			result.Metadata["mbc"] = romInfo.MBC.ToString();
+			result.Metadata["romBankCount"] = romInfo.RomBankCount;
+			result.Metadata["ramBankCount"] = romInfo.RamBankCount;
+
+			var extractType = GetExtractType(asset);
+
+			result = extractType.ToLowerInvariant() switch {
+				"bank" => await ExtractBankAsync(parser, asset, outputPath, result, cancellationToken),
+				"allbanks" => await ExtractAllBanksAsync(parser, asset, outputPath, result, cancellationToken),
+				"tiles" or "graphics" => await ExtractTilesAsync(romData, asset, outputPath, result, cancellationToken),
+				"palette" => await ExtractPaletteAsync(romData, asset, outputPath, result, cancellationToken),
+				"header" => await ExtractHeaderAsync(parser, outputPath, result, cancellationToken),
+				"vram" => await ExtractVramTilesAsync(romData, asset, outputPath, result, cancellationToken),
+				_ => await ExtractRawAsync(romData, asset, outputPath, result, cancellationToken)
+			};
+		} catch (Exception ex) {
+			result.Success = false;
+			result.Error = ex.Message;
+		}
+
+		return result;
+	}
+
+	private static string GetExtractType(AssetDefinition asset) {
+		if (asset.Options?.TryGetValue("extractType", out var extractType) == true) {
+			return extractType?.ToString() ?? "raw";
+		}
+		return "raw";
+	}
+
+	private static int ParseOffset(string? offset) {
+		if (string.IsNullOrEmpty(offset)) return 0;
+		return offset.StartsWith("0x", StringComparison.OrdinalIgnoreCase)
+			? Convert.ToInt32(offset, 16)
+			: int.Parse(offset);
+	}
+
+	private static int ParseLength(string? length) {
+		if (string.IsNullOrEmpty(length)) return 0;
+		return length.StartsWith("0x", StringComparison.OrdinalIgnoreCase)
+			? Convert.ToInt32(length, 16)
+			: int.Parse(length);
+	}
+
+	/// <summary>
+	/// Extract a single ROM bank.
+	/// </summary>
+	private async Task<AssetExtractionResult> ExtractBankAsync(
+		GameBoyRomParser parser,
+		AssetDefinition asset,
+		string outputPath,
+		AssetExtractionResult result,
+		CancellationToken cancellationToken) {
+		var bankIndex = 0;
+		if (asset.Options?.TryGetValue("bank", out var bankValue) == true) {
+			bankIndex = Convert.ToInt32(bankValue);
+		}
+
+		if (bankIndex < 0 || bankIndex >= parser.RomBankCount) {
+			result.Success = false;
+			result.Error = $"Bank {bankIndex} out of range (0-{parser.RomBankCount - 1})";
+			return result;
+		}
+
+		var bankData = parser.GetRomBank(bankIndex);
+
+		Directory.CreateDirectory(Path.GetDirectoryName(outputPath)!);
+		await File.WriteAllBytesAsync(outputPath, bankData, cancellationToken);
+
+		result.Success = true;
+		result.OutputPath = outputPath;
+		result.BytesExtracted = bankData.Length;
+		result.Metadata["bankIndex"] = bankIndex;
+		result.Metadata["bankSize"] = GameBoyRomParser.RomBankSize;
+
+		return result;
+	}
+
+	/// <summary>
+	/// Extract all ROM banks as separate files.
+	/// </summary>
+	private async Task<AssetExtractionResult> ExtractAllBanksAsync(
+		GameBoyRomParser parser,
+		AssetDefinition asset,
+		string outputPath,
+		AssetExtractionResult result,
+		CancellationToken cancellationToken) {
+		var outputDir = Path.GetDirectoryName(outputPath)!;
+		var baseName = Path.GetFileNameWithoutExtension(outputPath);
+		Directory.CreateDirectory(outputDir);
+
+		int totalBytes = 0;
+		for (int i = 0; i < parser.RomBankCount; i++) {
+			cancellationToken.ThrowIfCancellationRequested();
+
+			var bankData = parser.GetRomBank(i);
+			var bankPath = Path.Combine(outputDir, $"{baseName}_bank_{i:d2}.bin");
+			await File.WriteAllBytesAsync(bankPath, bankData, cancellationToken);
+			totalBytes += bankData.Length;
+		}
+
+		result.Success = true;
+		result.OutputPath = outputDir;
+		result.BytesExtracted = totalBytes;
+		result.Metadata["bankCount"] = parser.RomBankCount;
+		result.Metadata["bankSize"] = GameBoyRomParser.RomBankSize;
+
+		return result;
+	}
+
+	/// <summary>
+	/// Extract 2bpp tile graphics (Game Boy native format).
+	/// </summary>
+	private async Task<AssetExtractionResult> ExtractTilesAsync(
+		byte[] romData,
+		AssetDefinition asset,
+		string outputPath,
+		AssetExtractionResult result,
+		CancellationToken cancellationToken) {
+		var offset = ParseOffset(asset.Source?.Offset);
+		var length = ParseLength(asset.Source?.Length);
+		var bpp = 2; // Default to 2bpp for Game Boy
+
+		if (asset.Options?.TryGetValue("bpp", out var bppValue) == true) {
+			bpp = Convert.ToInt32(bppValue);
+		}
+
+		// Calculate tile count
+		var bytesPerTile = bpp * 8; // 2bpp = 16 bytes, 4bpp = 32 bytes
+		var tileCount = length / bytesPerTile;
+
+		if (tileCount <= 0) {
+			result.Success = false;
+			result.Error = "Invalid tile data length";
+			return result;
+		}
+
+		// Extract tile data
+		var tileData = new byte[length];
+		Array.Copy(romData, offset, tileData, 0, length);
+
+		// Delegate to graphics extractor for PNG conversion
+		var graphicsExtractor = AssetExtractorFactory.GetExtractor(AssetType.Graphics, Platform.Gb);
+		var graphicsResult = await graphicsExtractor.ExtractAsync(
+			romData, asset, outputPath,
+			new AssetsConfig(), cancellationToken);
+
+		if (graphicsResult.Success) {
+			result.Success = true;
+			result.OutputPath = graphicsResult.OutputPath;
+			result.BytesExtracted = length;
+		} else {
+			// Fall back to binary extraction
+			Directory.CreateDirectory(Path.GetDirectoryName(outputPath)!);
+			var binPath = Path.ChangeExtension(outputPath, ".bin");
+			await File.WriteAllBytesAsync(binPath, tileData, cancellationToken);
+
+			result.Success = true;
+			result.OutputPath = binPath;
+			result.BytesExtracted = length;
+		}
+
+		result.Metadata["format"] = $"{bpp}bpp tiles";
+		result.Metadata["tileCount"] = tileCount;
+		result.Metadata["offset"] = offset;
+
+		return result;
+	}
+
+	/// <summary>
+	/// Extract GBC palette (15-bit RGB).
+	/// </summary>
+	private async Task<AssetExtractionResult> ExtractPaletteAsync(
+		byte[] romData,
+		AssetDefinition asset,
+		string outputPath,
+		AssetExtractionResult result,
+		CancellationToken cancellationToken) {
+		var offset = ParseOffset(asset.Source?.Offset);
+		var colorCount = 4; // Default 4 colors per palette
+
+		if (asset.Options?.TryGetValue("colors", out var colorsValue) == true) {
+			colorCount = Convert.ToInt32(colorsValue);
+		}
+
+		// GBC palette: 2 bytes per color (15-bit RGB: 0bbbbbgg gggrrrrr)
+		var bytesNeeded = colorCount * 2;
+		var colors = new List<Dictionary<string, object>>();
+
+		for (int i = 0; i < colorCount; i++) {
+			var colorOffset = offset + (i * 2);
+			if (colorOffset + 1 >= romData.Length) break;
+
+			// Little-endian 16-bit value
+			var rawColor = romData[colorOffset] | (romData[colorOffset + 1] << 8);
+
+			// Extract 5-bit components
+			var r5 = rawColor & 0x1f;
+			var g5 = (rawColor >> 5) & 0x1f;
+			var b5 = (rawColor >> 10) & 0x1f;
+
+			// Convert to 8-bit
+			var r8 = (r5 << 3) | (r5 >> 2);
+			var g8 = (g5 << 3) | (g5 >> 2);
+			var b8 = (b5 << 3) | (b5 >> 2);
+
+			colors.Add(new Dictionary<string, object> {
+				["index"] = i,
+				["raw"] = $"0x{rawColor:x4}",
+				["r5"] = r5, ["g5"] = g5, ["b5"] = b5,
+				["r"] = r8, ["g"] = g8, ["b"] = b8,
+				["hex"] = $"#{r8:x2}{g8:x2}{b8:x2}"
+			});
+		}
+
+		var palette = new Dictionary<string, object> {
+			["name"] = asset.Name,
+			["format"] = "GBC 15-bit RGB",
+			["offset"] = $"0x{offset:x}",
+			["colorCount"] = colorCount,
+			["colors"] = colors
+		};
+
+		Directory.CreateDirectory(Path.GetDirectoryName(outputPath)!);
+		var json = System.Text.Json.JsonSerializer.Serialize(palette,
+			new System.Text.Json.JsonSerializerOptions { WriteIndented = true });
+		await File.WriteAllTextAsync(outputPath, json, cancellationToken);
+
+		result.Success = true;
+		result.OutputPath = outputPath;
+		result.BytesExtracted = bytesNeeded;
+		result.Metadata["format"] = "GBC 15-bit RGB";
+		result.Metadata["colorCount"] = colorCount;
+
+		return result;
+	}
+
+	/// <summary>
+	/// Extract header information as JSON.
+	/// </summary>
+	private async Task<AssetExtractionResult> ExtractHeaderAsync(
+		GameBoyRomParser parser,
+		string outputPath,
+		AssetExtractionResult result,
+		CancellationToken cancellationToken) {
+		var info = parser.GetRomInfo();
+
+		var headerData = new Dictionary<string, object> {
+			["title"] = info.Title,
+			["isGameBoyColor"] = info.IsGameBoyColor,
+			["isSuperGameBoy"] = info.IsSuperGameBoy,
+			["mbc"] = info.MBC.ToString(),
+			["romSize"] = info.RomSize,
+			["romBankCount"] = info.RomBankCount,
+			["ramSize"] = info.RamSize,
+			["ramBankCount"] = info.RamBankCount,
+			["hasBattery"] = info.HasBattery,
+			["hasTimer"] = info.HasTimer,
+			["hasRumble"] = info.HasRumble,
+			["region"] = info.Region.ToString(),
+			["headerChecksumValid"] = info.HeaderChecksumValid,
+			["globalChecksumValid"] = info.GlobalChecksumValid,
+			["logoValid"] = info.LogoValid
+		};
+
+		Directory.CreateDirectory(Path.GetDirectoryName(outputPath)!);
+		var json = System.Text.Json.JsonSerializer.Serialize(headerData,
+			new System.Text.Json.JsonSerializerOptions { WriteIndented = true });
+		await File.WriteAllTextAsync(outputPath, json, cancellationToken);
+
+		result.Success = true;
+		result.OutputPath = outputPath;
+		result.BytesExtracted = 0x50; // Header is $100-$14F
+		result.Metadata["title"] = info.Title;
+
+		return result;
+	}
+
+	/// <summary>
+	/// Extract VRAM-mapped tiles ($8000-$97FF layout).
+	/// </summary>
+	private async Task<AssetExtractionResult> ExtractVramTilesAsync(
+		byte[] romData,
+		AssetDefinition asset,
+		string outputPath,
+		AssetExtractionResult result,
+		CancellationToken cancellationToken) {
+		// VRAM tiles are organized in 3 blocks of 128 tiles each
+		// Block 0: $8000-$87FF (used by OBJ and background)
+		// Block 1: $8800-$8FFF (shared between BG addressing modes)
+		// Block 2: $9000-$97FF (used by background)
+
+		var offset = ParseOffset(asset.Source?.Offset);
+		var blockCount = 3;
+
+		if (asset.Options?.TryGetValue("blocks", out var blocksValue) == true) {
+			blockCount = Convert.ToInt32(blocksValue);
+		}
+
+		var bytesPerBlock = 0x800; // 2KB per block
+		var totalLength = blockCount * bytesPerBlock;
+
+		if (offset + totalLength > romData.Length) {
+			result.Success = false;
+			result.Error = "VRAM tile data extends beyond ROM";
+			return result;
+		}
+
+		// Extract all blocks as one binary file
+		var tileData = new byte[totalLength];
+		Array.Copy(romData, offset, tileData, 0, totalLength);
+
+		Directory.CreateDirectory(Path.GetDirectoryName(outputPath)!);
+		await File.WriteAllBytesAsync(outputPath, tileData, cancellationToken);
+
+		result.Success = true;
+		result.OutputPath = outputPath;
+		result.BytesExtracted = totalLength;
+		result.Metadata["blockCount"] = blockCount;
+		result.Metadata["tilesPerBlock"] = 128;
+		result.Metadata["totalTiles"] = blockCount * 128;
+
+		return result;
+	}
+
+	/// <summary>
+	/// Extract raw binary data.
+	/// </summary>
+	private async Task<AssetExtractionResult> ExtractRawAsync(
+		byte[] romData,
+		AssetDefinition asset,
+		string outputPath,
+		AssetExtractionResult result,
+		CancellationToken cancellationToken) {
+		var offset = ParseOffset(asset.Source?.Offset);
+		var length = ParseLength(asset.Source?.Length);
+
+		if (length <= 0) {
+			length = romData.Length - offset;
+		}
+
+		if (offset + length > romData.Length) {
+			length = romData.Length - offset;
+		}
+
+		var data = new byte[length];
+		Array.Copy(romData, offset, data, 0, length);
+
+		Directory.CreateDirectory(Path.GetDirectoryName(outputPath)!);
+		await File.WriteAllBytesAsync(outputPath, data, cancellationToken);
+
+		result.Success = true;
+		result.OutputPath = outputPath;
+		result.BytesExtracted = length;
+		result.Metadata["offset"] = $"0x{offset:x}";
+		result.Metadata["length"] = length;
+
+		return result;
+	}
+}

--- a/src/GameInfoTools.Core/Build/GameBoyRomParser.cs
+++ b/src/GameInfoTools.Core/Build/GameBoyRomParser.cs
@@ -1,0 +1,509 @@
+namespace GameInfoTools.Core.Build;
+
+/// <summary>
+/// Game Boy / Game Boy Color ROM parsing and bank extraction utilities.
+/// Supports MBC1, MBC2, MBC3, MBC5, and other memory bank controllers.
+/// </summary>
+public class GameBoyRomParser {
+	private readonly byte[] _romData;
+	private readonly GameBoyHeader _header;
+
+	/// <summary>
+	/// Game Boy ROM bank size (16KB)
+	/// </summary>
+	public const int RomBankSize = 0x4000;
+
+	/// <summary>
+	/// Game Boy RAM bank size (8KB)
+	/// </summary>
+	public const int RamBankSize = 0x2000;
+
+	/// <summary>
+	/// Game Boy tile size (8x8 pixels)
+	/// </summary>
+	public const int TileSize = 8;
+
+	/// <summary>
+	/// Header offset in ROM
+	/// </summary>
+	public const int HeaderOffset = 0x100;
+
+	public GameBoyRomParser(byte[] romData) {
+		_romData = romData ?? throw new ArgumentNullException(nameof(romData));
+		_header = ParseHeader();
+	}
+
+	/// <summary>
+	/// Gets the parsed Game Boy header.
+	/// </summary>
+	public GameBoyHeader Header => _header;
+
+	/// <summary>
+	/// Gets the ROM size in bytes.
+	/// </summary>
+	public int RomSize => _romData.Length;
+
+	/// <summary>
+	/// Gets whether this is a Game Boy Color ROM.
+	/// </summary>
+	public bool IsGameBoyColor => _header.CgbFlag == CgbSupport.CgbOnly ||
+								   _header.CgbFlag == CgbSupport.CgbEnhanced;
+
+	/// <summary>
+	/// Gets whether this is a Super Game Boy enhanced ROM.
+	/// </summary>
+	public bool IsSuperGameBoy => _header.SgbFlag;
+
+	/// <summary>
+	/// Gets the number of ROM banks.
+	/// </summary>
+	public int RomBankCount => _header.RomBanks;
+
+	/// <summary>
+	/// Gets the number of RAM banks.
+	/// </summary>
+	public int RamBankCount => _header.RamBanks;
+
+	/// <summary>
+	/// Parse the Game Boy ROM header.
+	/// </summary>
+	private GameBoyHeader ParseHeader() {
+		var header = new GameBoyHeader();
+
+		if (_romData.Length < 0x150) {
+			return header;
+		}
+
+		// Entry point at $100-$103 (usually NOP; JP $150)
+		header.EntryPoint = new byte[4];
+		Array.Copy(_romData, 0x100, header.EntryPoint, 0, 4);
+
+		// Nintendo logo at $104-$133 (48 bytes)
+		header.NintendoLogo = new byte[48];
+		Array.Copy(_romData, 0x104, header.NintendoLogo, 0, 48);
+
+		// Verify Nintendo logo
+		header.LogoValid = VerifyNintendoLogo(header.NintendoLogo);
+
+		// Title at $134-$143 (16 bytes, or 11 if CGB)
+		// Check CGB flag first
+		header.CgbFlag = GetCgbSupport(_romData[0x143]);
+
+		// Title length depends on CGB flag usage
+		var titleLength = header.CgbFlag != CgbSupport.None ? 11 : 16;
+		var titleBytes = new byte[titleLength];
+		Array.Copy(_romData, 0x134, titleBytes, 0, titleLength);
+		header.Title = System.Text.Encoding.ASCII.GetString(titleBytes).TrimEnd('\0', ' ');
+
+		// Manufacturer code at $13f-$142 (4 bytes, CGB only)
+		if (header.CgbFlag != CgbSupport.None) {
+			var mfgBytes = new byte[4];
+			Array.Copy(_romData, 0x13f, mfgBytes, 0, 4);
+			header.ManufacturerCode = System.Text.Encoding.ASCII.GetString(mfgBytes).TrimEnd('\0');
+		}
+
+		// New licensee code at $144-$145
+		header.NewLicenseeCode = System.Text.Encoding.ASCII.GetString(
+			new[] { _romData[0x144], _romData[0x145] });
+
+		// SGB flag at $146
+		header.SgbFlag = _romData[0x146] == 0x03;
+
+		// Cartridge type at $147
+		header.CartridgeType = _romData[0x147];
+		header.MBC = GetMbcType(header.CartridgeType);
+		header.HasRam = HasCartridgeRam(header.CartridgeType);
+		header.HasBattery = HasCartridgeBattery(header.CartridgeType);
+		header.HasTimer = HasCartridgeTimer(header.CartridgeType);
+		header.HasRumble = HasCartridgeRumble(header.CartridgeType);
+
+		// ROM size at $148
+		header.RomSizeCode = _romData[0x148];
+		header.RomBanks = GetRomBankCount(header.RomSizeCode);
+
+		// RAM size at $149
+		header.RamSizeCode = _romData[0x149];
+		header.RamBanks = GetRamBankCount(header.RamSizeCode);
+		header.RamSize = header.RamBanks * RamBankSize;
+
+		// Destination code at $14a
+		header.DestinationCode = _romData[0x14a];
+		header.Region = header.DestinationCode == 0 ? GameBoyRegion.Japan : GameBoyRegion.Overseas;
+
+		// Old licensee code at $14b
+		header.OldLicenseeCode = _romData[0x14b];
+
+		// Mask ROM version at $14c
+		header.Version = _romData[0x14c];
+
+		// Header checksum at $14d
+		header.HeaderChecksum = _romData[0x14d];
+		header.HeaderChecksumValid = VerifyHeaderChecksum();
+
+		// Global checksum at $14e-$14f (big-endian)
+		header.GlobalChecksum = (ushort)((_romData[0x14e] << 8) | _romData[0x14f]);
+
+		return header;
+	}
+
+	/// <summary>
+	/// Verify the Nintendo logo bytes.
+	/// </summary>
+	private static bool VerifyNintendoLogo(byte[] logo) {
+		byte[] expectedLogo = [
+			0xce, 0xed, 0x66, 0x66, 0xcc, 0x0d, 0x00, 0x0b,
+			0x03, 0x73, 0x00, 0x83, 0x00, 0x0c, 0x00, 0x0d,
+			0x00, 0x08, 0x11, 0x1f, 0x88, 0x89, 0x00, 0x0e,
+			0xdc, 0xcc, 0x6e, 0xe6, 0xdd, 0xdd, 0xd9, 0x99,
+			0xbb, 0xbb, 0x67, 0x63, 0x6e, 0x0e, 0xec, 0xcc,
+			0xdd, 0xdc, 0x99, 0x9f, 0xbb, 0xb9, 0x33, 0x3e
+		];
+
+		if (logo.Length != expectedLogo.Length) return false;
+
+		for (int i = 0; i < logo.Length; i++) {
+			if (logo[i] != expectedLogo[i]) return false;
+		}
+
+		return true;
+	}
+
+	/// <summary>
+	/// Verify the header checksum.
+	/// </summary>
+	public bool VerifyHeaderChecksum() {
+		byte checksum = 0;
+		for (int i = 0x134; i <= 0x14c; i++) {
+			checksum = (byte)(checksum - _romData[i] - 1);
+		}
+		return checksum == _romData[0x14d];
+	}
+
+	/// <summary>
+	/// Calculate the header checksum.
+	/// </summary>
+	public byte CalculateHeaderChecksum() {
+		byte checksum = 0;
+		for (int i = 0x134; i <= 0x14c; i++) {
+			checksum = (byte)(checksum - _romData[i] - 1);
+		}
+		return checksum;
+	}
+
+	/// <summary>
+	/// Calculate the global checksum.
+	/// </summary>
+	public ushort CalculateGlobalChecksum() {
+		uint sum = 0;
+		for (int i = 0; i < _romData.Length; i++) {
+			// Exclude checksum bytes themselves
+			if (i != 0x14e && i != 0x14f) {
+				sum += _romData[i];
+			}
+		}
+		return (ushort)(sum & 0xffff);
+	}
+
+	/// <summary>
+	/// Verify the global checksum.
+	/// </summary>
+	public bool VerifyGlobalChecksum() {
+		return _header.GlobalChecksum == CalculateGlobalChecksum();
+	}
+
+	/// <summary>
+	/// Get CGB support level.
+	/// </summary>
+	private static CgbSupport GetCgbSupport(byte flag) {
+		return flag switch {
+			0x80 => CgbSupport.CgbEnhanced,
+			0xc0 => CgbSupport.CgbOnly,
+			_ => CgbSupport.None
+		};
+	}
+
+	/// <summary>
+	/// Get MBC type from cartridge type byte.
+	/// </summary>
+	private static MbcType GetMbcType(byte cartType) {
+		return cartType switch {
+			0x00 => MbcType.None,
+			0x01 or 0x02 or 0x03 => MbcType.MBC1,
+			0x05 or 0x06 => MbcType.MBC2,
+			0x08 or 0x09 => MbcType.None, // ROM+RAM
+			0x0b or 0x0c or 0x0d => MbcType.MMM01,
+			0x0f or 0x10 or 0x11 or 0x12 or 0x13 => MbcType.MBC3,
+			0x19 or 0x1a or 0x1b or 0x1c or 0x1d or 0x1e => MbcType.MBC5,
+			0x20 => MbcType.MBC6,
+			0x22 => MbcType.MBC7,
+			0xfc => MbcType.PocketCamera,
+			0xfd => MbcType.BandaiTama5,
+			0xfe => MbcType.HuC3,
+			0xff => MbcType.HuC1,
+			_ => MbcType.Unknown
+		};
+	}
+
+	/// <summary>
+	/// Check if cartridge has RAM.
+	/// </summary>
+	private static bool HasCartridgeRam(byte cartType) {
+		return cartType is 0x02 or 0x03 or 0x08 or 0x09 or 0x0c or 0x0d
+			or 0x10 or 0x12 or 0x13 or 0x1a or 0x1b or 0x1d or 0x1e
+			or 0x22 or 0xff;
+	}
+
+	/// <summary>
+	/// Check if cartridge has battery.
+	/// </summary>
+	private static bool HasCartridgeBattery(byte cartType) {
+		return cartType is 0x03 or 0x06 or 0x09 or 0x0d or 0x0f or 0x10
+			or 0x13 or 0x1b or 0x1e or 0x22 or 0xff;
+	}
+
+	/// <summary>
+	/// Check if cartridge has timer.
+	/// </summary>
+	private static bool HasCartridgeTimer(byte cartType) {
+		return cartType is 0x0f or 0x10;
+	}
+
+	/// <summary>
+	/// Check if cartridge has rumble.
+	/// </summary>
+	private static bool HasCartridgeRumble(byte cartType) {
+		return cartType is 0x1c or 0x1d or 0x1e;
+	}
+
+	/// <summary>
+	/// Get ROM bank count from size code.
+	/// </summary>
+	private static int GetRomBankCount(byte sizeCode) {
+		return sizeCode switch {
+			0x00 => 2,   // 32KB
+			0x01 => 4,   // 64KB
+			0x02 => 8,   // 128KB
+			0x03 => 16,  // 256KB
+			0x04 => 32,  // 512KB
+			0x05 => 64,  // 1MB
+			0x06 => 128, // 2MB
+			0x07 => 256, // 4MB
+			0x08 => 512, // 8MB
+			0x52 => 72,  // 1.1MB
+			0x53 => 80,  // 1.2MB
+			0x54 => 96,  // 1.5MB
+			_ => 2
+		};
+	}
+
+	/// <summary>
+	/// Get RAM bank count from size code.
+	/// </summary>
+	private static int GetRamBankCount(byte sizeCode) {
+		return sizeCode switch {
+			0x00 => 0,   // No RAM
+			0x01 => 1,   // 2KB (unused)
+			0x02 => 1,   // 8KB
+			0x03 => 4,   // 32KB
+			0x04 => 16,  // 128KB
+			0x05 => 8,   // 64KB
+			_ => 0
+		};
+	}
+
+	/// <summary>
+	/// Get a specific ROM bank.
+	/// </summary>
+	public byte[] GetRomBank(int bankIndex) {
+		if (bankIndex < 0 || bankIndex >= RomBankCount) {
+			throw new ArgumentOutOfRangeException(nameof(bankIndex),
+				$"Bank index {bankIndex} out of range (0-{RomBankCount - 1})");
+		}
+
+		var offset = bankIndex * RomBankSize;
+		var length = Math.Min(RomBankSize, _romData.Length - offset);
+		var bank = new byte[length];
+		Array.Copy(_romData, offset, bank, 0, length);
+		return bank;
+	}
+
+	/// <summary>
+	/// Get all ROM data.
+	/// </summary>
+	public byte[] GetRomData() {
+		var data = new byte[_romData.Length];
+		Array.Copy(_romData, data, _romData.Length);
+		return data;
+	}
+
+	/// <summary>
+	/// Fix the header checksum.
+	/// </summary>
+	public static byte[] FixHeaderChecksum(byte[] romData) {
+		var parser = new GameBoyRomParser(romData);
+		var checksum = parser.CalculateHeaderChecksum();
+
+		var result = new byte[romData.Length];
+		Array.Copy(romData, result, romData.Length);
+		result[0x14d] = checksum;
+
+		return result;
+	}
+
+	/// <summary>
+	/// Fix both header and global checksums.
+	/// </summary>
+	public static byte[] FixChecksums(byte[] romData) {
+		var result = new byte[romData.Length];
+		Array.Copy(romData, result, romData.Length);
+
+		// Fix header checksum first
+		var parser = new GameBoyRomParser(result);
+		result[0x14d] = parser.CalculateHeaderChecksum();
+
+		// Recalculate global checksum
+		parser = new GameBoyRomParser(result);
+		var globalChecksum = parser.CalculateGlobalChecksum();
+		result[0x14e] = (byte)((globalChecksum >> 8) & 0xff);
+		result[0x14f] = (byte)(globalChecksum & 0xff);
+
+		return result;
+	}
+
+	/// <summary>
+	/// Get ROM information summary.
+	/// </summary>
+	public GameBoyRomInfo GetRomInfo() {
+		return new GameBoyRomInfo {
+			Title = _header.Title,
+			IsGameBoyColor = IsGameBoyColor,
+			IsSuperGameBoy = IsSuperGameBoy,
+			MBC = _header.MBC,
+			RomSize = RomSize,
+			RomBankCount = RomBankCount,
+			RamSize = _header.RamSize,
+			RamBankCount = RamBankCount,
+			HasBattery = _header.HasBattery,
+			HasTimer = _header.HasTimer,
+			HasRumble = _header.HasRumble,
+			Region = _header.Region,
+			HeaderChecksumValid = _header.HeaderChecksumValid,
+			GlobalChecksumValid = VerifyGlobalChecksum(),
+			LogoValid = _header.LogoValid
+		};
+	}
+
+	/// <summary>
+	/// Extract all ROM banks as separate files.
+	/// </summary>
+	public async Task ExtractBanksAsync(string outputDir, CancellationToken cancellationToken = default) {
+		Directory.CreateDirectory(outputDir);
+
+		for (int i = 0; i < RomBankCount; i++) {
+			cancellationToken.ThrowIfCancellationRequested();
+			var bank = GetRomBank(i);
+			var path = Path.Combine(outputDir, $"bank_{i:d2}.bin");
+			await File.WriteAllBytesAsync(path, bank, cancellationToken);
+		}
+
+		// Extract header info
+		var infoPath = Path.Combine(outputDir, "rom_info.json");
+		var info = GetRomInfo();
+		var json = System.Text.Json.JsonSerializer.Serialize(info, new System.Text.Json.JsonSerializerOptions {
+			WriteIndented = true
+		});
+		await File.WriteAllTextAsync(infoPath, json, cancellationToken);
+	}
+}
+
+/// <summary>
+/// Parsed Game Boy ROM header.
+/// </summary>
+public class GameBoyHeader {
+	public byte[] EntryPoint { get; set; } = [];
+	public byte[] NintendoLogo { get; set; } = [];
+	public bool LogoValid { get; set; }
+	public string Title { get; set; } = "";
+	public string ManufacturerCode { get; set; } = "";
+	public CgbSupport CgbFlag { get; set; }
+	public string NewLicenseeCode { get; set; } = "";
+	public bool SgbFlag { get; set; }
+	public byte CartridgeType { get; set; }
+	public MbcType MBC { get; set; }
+	public bool HasRam { get; set; }
+	public bool HasBattery { get; set; }
+	public bool HasTimer { get; set; }
+	public bool HasRumble { get; set; }
+	public byte RomSizeCode { get; set; }
+	public int RomBanks { get; set; }
+	public byte RamSizeCode { get; set; }
+	public int RamBanks { get; set; }
+	public int RamSize { get; set; }
+	public byte DestinationCode { get; set; }
+	public GameBoyRegion Region { get; set; }
+	public byte OldLicenseeCode { get; set; }
+	public byte Version { get; set; }
+	public byte HeaderChecksum { get; set; }
+	public bool HeaderChecksumValid { get; set; }
+	public ushort GlobalChecksum { get; set; }
+}
+
+/// <summary>
+/// Game Boy Color support levels.
+/// </summary>
+public enum CgbSupport {
+	/// <summary>No CGB support (original GB)</summary>
+	None,
+	/// <summary>CGB enhanced (works on both)</summary>
+	CgbEnhanced,
+	/// <summary>CGB only (doesn't work on DMG)</summary>
+	CgbOnly
+}
+
+/// <summary>
+/// Memory Bank Controller types.
+/// </summary>
+public enum MbcType {
+	None,
+	MBC1,
+	MBC2,
+	MBC3,
+	MBC5,
+	MBC6,
+	MBC7,
+	MMM01,
+	PocketCamera,
+	BandaiTama5,
+	HuC1,
+	HuC3,
+	Unknown
+}
+
+/// <summary>
+/// Game Boy region codes.
+/// </summary>
+public enum GameBoyRegion {
+	Japan,
+	Overseas
+}
+
+/// <summary>
+/// Summary information about a Game Boy ROM.
+/// </summary>
+public class GameBoyRomInfo {
+	public string Title { get; init; } = "";
+	public bool IsGameBoyColor { get; init; }
+	public bool IsSuperGameBoy { get; init; }
+	public MbcType MBC { get; init; }
+	public int RomSize { get; init; }
+	public int RomBankCount { get; init; }
+	public int RamSize { get; init; }
+	public int RamBankCount { get; init; }
+	public bool HasBattery { get; init; }
+	public bool HasTimer { get; init; }
+	public bool HasRumble { get; init; }
+	public GameBoyRegion Region { get; init; }
+	public bool HeaderChecksumValid { get; init; }
+	public bool GlobalChecksumValid { get; init; }
+	public bool LogoValid { get; init; }
+}

--- a/src/GameInfoTools.Tests/GameBoyAssetExtractorTests.cs
+++ b/src/GameInfoTools.Tests/GameBoyAssetExtractorTests.cs
@@ -1,0 +1,285 @@
+using GameInfoTools.Core.Build;
+
+namespace GameInfoTools.Tests;
+
+/// <summary>
+/// Tests for GameBoyAssetExtractor functionality.
+/// </summary>
+public class GameBoyAssetExtractorTests : IDisposable {
+	private readonly string _tempDir;
+
+	public GameBoyAssetExtractorTests() {
+		_tempDir = Path.Combine(Path.GetTempPath(), "GameBoyAssetExtractorTests_" + Guid.NewGuid().ToString("N"));
+		Directory.CreateDirectory(_tempDir);
+	}
+
+	/// <summary>
+	/// Creates a minimal valid Game Boy ROM for testing.
+	/// </summary>
+	private static byte[] CreateMinimalGameBoyRom() {
+		var romData = new byte[0x8000]; // 32KB minimum
+
+		// Entry point at $100
+		romData[0x100] = 0x00;
+		romData[0x101] = 0xc3;
+		romData[0x102] = 0x50;
+		romData[0x103] = 0x01;
+
+		// Nintendo logo
+		var nintendoLogo = new byte[] {
+			0xce, 0xed, 0x66, 0x66, 0xcc, 0x0d, 0x00, 0x0b,
+			0x03, 0x73, 0x00, 0x83, 0x00, 0x0c, 0x00, 0x0d,
+			0x00, 0x08, 0x11, 0x1f, 0x88, 0x89, 0x00, 0x0e,
+			0xdc, 0xcc, 0x6e, 0xe6, 0xdd, 0xdd, 0xd9, 0x99,
+			0xbb, 0xbb, 0x67, 0x63, 0x6e, 0x0e, 0xec, 0xcc,
+			0xdd, 0xdc, 0x99, 0x9f, 0xbb, 0xb9, 0x33, 0x3e
+		};
+		Array.Copy(nintendoLogo, 0, romData, 0x104, nintendoLogo.Length);
+
+		// Title
+		var title = System.Text.Encoding.ASCII.GetBytes("TESTGAME");
+		Array.Copy(title, 0, romData, 0x134, title.Length);
+
+		// Cartridge type (ROM only)
+		romData[0x147] = 0x00;
+		romData[0x148] = 0x00; // 32KB
+		romData[0x149] = 0x00; // No RAM
+		romData[0x14A] = 0x01; // Non-Japanese
+		romData[0x14B] = 0x33; // New licensee
+
+		// Calculate header checksum
+		int checksum = 0;
+		for (int i = 0x134; i <= 0x14C; i++) {
+			checksum = checksum - romData[i] - 1;
+		}
+		romData[0x14D] = (byte)(checksum & 0xff);
+
+		return romData;
+	}
+
+	[Fact]
+	public async Task ExtractAsync_WithBankType_ExtractsSingleBank() {
+		var romData = CreateMinimalGameBoyRom();
+		// Add some recognizable data to bank 0
+		romData[0x200] = 0xAB;
+		romData[0x201] = 0xCD;
+
+		var extractor = new GameBoyAssetExtractor();
+		var asset = new AssetDefinition {
+			Name = "bank0",
+			Type = AssetType.Data,
+			Source = new AssetSource(),
+			Options = new Dictionary<string, object?> {
+				["extractType"] = "bank",
+				["bank"] = 0
+			}
+		};
+		var outputPath = Path.Combine(_tempDir, "bank0.bin");
+
+		var result = await extractor.ExtractAsync(romData, asset, outputPath, new AssetsConfig());
+
+		Assert.True(result.Success);
+		Assert.True(File.Exists(outputPath));
+		var extractedData = await File.ReadAllBytesAsync(outputPath);
+		Assert.Equal(0x4000, extractedData.Length);
+		Assert.Equal(0xAB, extractedData[0x200]);
+		Assert.Equal(0xCD, extractedData[0x201]);
+	}
+
+	[Fact]
+	public async Task ExtractAsync_WithAllBanksType_ExtractsAllBanks() {
+		var romData = CreateMinimalGameBoyRom();
+
+		var extractor = new GameBoyAssetExtractor();
+		var asset = new AssetDefinition {
+			Name = "allbanks",
+			Type = AssetType.Data,
+			Source = new AssetSource(),
+			Options = new Dictionary<string, object?> {
+				["extractType"] = "allbanks"
+			}
+		};
+		var outputPath = Path.Combine(_tempDir, "banks", "bank.bin");
+
+		var result = await extractor.ExtractAsync(romData, asset, outputPath, new AssetsConfig());
+
+		Assert.True(result.Success);
+		Assert.True(File.Exists(Path.Combine(_tempDir, "banks", "bank_bank_00.bin")));
+		Assert.True(File.Exists(Path.Combine(_tempDir, "banks", "bank_bank_01.bin")));
+		Assert.Equal(2, result.Metadata["bankCount"]);
+	}
+
+	[Fact]
+	public async Task ExtractAsync_WithHeaderType_ExtractsHeaderAsJson() {
+		var romData = CreateMinimalGameBoyRom();
+
+		var extractor = new GameBoyAssetExtractor();
+		var asset = new AssetDefinition {
+			Name = "header",
+			Type = AssetType.Data,
+			Source = new AssetSource(),
+			Options = new Dictionary<string, object?> {
+				["extractType"] = "header"
+			}
+		};
+		var outputPath = Path.Combine(_tempDir, "header.json");
+
+		var result = await extractor.ExtractAsync(romData, asset, outputPath, new AssetsConfig());
+
+		Assert.True(result.Success);
+		Assert.True(File.Exists(outputPath));
+		var json = await File.ReadAllTextAsync(outputPath);
+		Assert.Contains("TESTGAME", json);
+		Assert.Contains("mbc", json);
+	}
+
+	[Fact]
+	public async Task ExtractAsync_WithPaletteType_ExtractsGbcPalette() {
+		var romData = CreateMinimalGameBoyRom();
+		// Add a GBC palette at a known offset (15-bit RGB: 0bbbbbgggggrrrrr)
+		// White: R=31, G=31, B=31 = 0x7FFF
+		// Red: R=31, G=0, B=0 = 0x001F
+		// Green: R=0, G=31, B=0 = 0x03E0
+		// Blue: R=0, G=0, B=31 = 0x7C00
+		romData[0x1000] = 0xFF; romData[0x1001] = 0x7F; // White
+		romData[0x1002] = 0x1F; romData[0x1003] = 0x00; // Red
+		romData[0x1004] = 0xE0; romData[0x1005] = 0x03; // Green
+		romData[0x1006] = 0x00; romData[0x1007] = 0x7C; // Blue
+
+		var extractor = new GameBoyAssetExtractor();
+		var asset = new AssetDefinition {
+			Name = "palette",
+			Type = AssetType.Palette,
+			Source = new AssetSource {
+				Offset = "0x1000"
+			},
+			Options = new Dictionary<string, object?> {
+				["extractType"] = "palette",
+				["colors"] = 4
+			}
+		};
+		var outputPath = Path.Combine(_tempDir, "palette.json");
+
+		var result = await extractor.ExtractAsync(romData, asset, outputPath, new AssetsConfig());
+
+		Assert.True(result.Success);
+		Assert.True(File.Exists(outputPath));
+		var json = await File.ReadAllTextAsync(outputPath);
+		Assert.Contains("#ffffff", json); // White
+		Assert.Contains("colorCount", json);
+	}
+
+	[Fact]
+	public async Task ExtractAsync_WithRawType_ExtractsRawBytes() {
+		var romData = CreateMinimalGameBoyRom();
+		// Add some test data
+		for (int i = 0; i < 256; i++) {
+			romData[0x1000 + i] = (byte)i;
+		}
+
+		var extractor = new GameBoyAssetExtractor();
+		var asset = new AssetDefinition {
+			Name = "raw_data",
+			Type = AssetType.Data,
+			Source = new AssetSource {
+				Offset = "0x1000",
+				Length = "0x100"
+			}
+		};
+		var outputPath = Path.Combine(_tempDir, "raw.bin");
+
+		var result = await extractor.ExtractAsync(romData, asset, outputPath, new AssetsConfig());
+
+		Assert.True(result.Success);
+		Assert.True(File.Exists(outputPath));
+		var extractedData = await File.ReadAllBytesAsync(outputPath);
+		Assert.Equal(256, extractedData.Length);
+		for (int i = 0; i < 256; i++) {
+			Assert.Equal((byte)i, extractedData[i]);
+		}
+	}
+
+	[Fact]
+	public async Task ExtractAsync_WithInvalidBank_ReturnsError() {
+		var romData = CreateMinimalGameBoyRom();
+
+		var extractor = new GameBoyAssetExtractor();
+		var asset = new AssetDefinition {
+			Name = "bank99",
+			Type = AssetType.Data,
+			Source = new AssetSource(),
+			Options = new Dictionary<string, object?> {
+				["extractType"] = "bank",
+				["bank"] = 99
+			}
+		};
+		var outputPath = Path.Combine(_tempDir, "bank99.bin");
+
+		var result = await extractor.ExtractAsync(romData, asset, outputPath, new AssetsConfig());
+
+		Assert.False(result.Success);
+		Assert.Contains("out of range", result.Error);
+	}
+
+	[Fact]
+	public async Task ExtractAsync_IncludesRomMetadata() {
+		var romData = CreateMinimalGameBoyRom();
+
+		var extractor = new GameBoyAssetExtractor();
+		var asset = new AssetDefinition {
+			Name = "data",
+			Type = AssetType.Data,
+			Source = new AssetSource {
+				Offset = "0x100",
+				Length = "0x10"
+			}
+		};
+		var outputPath = Path.Combine(_tempDir, "data.bin");
+
+		var result = await extractor.ExtractAsync(romData, asset, outputPath, new AssetsConfig());
+
+		Assert.True(result.Success);
+		Assert.Equal("TESTGAME", result.Metadata["title"]);
+		Assert.Equal(2, result.Metadata["romBankCount"]);
+	}
+
+	[Fact]
+	public async Task ExtractAsync_WithVramType_ExtractsVramTiles() {
+		var romData = CreateMinimalGameBoyRom();
+		// Add some tile data at offset $200
+		for (int i = 0; i < 0x800; i++) {
+			romData[0x200 + i] = (byte)(i & 0xff);
+		}
+
+		var extractor = new GameBoyAssetExtractor();
+		var asset = new AssetDefinition {
+			Name = "vram_tiles",
+			Type = AssetType.Graphics,
+			Source = new AssetSource {
+				Offset = "0x200"
+			},
+			Options = new Dictionary<string, object?> {
+				["extractType"] = "vram",
+				["blocks"] = 1
+			}
+		};
+		var outputPath = Path.Combine(_tempDir, "vram.bin");
+
+		var result = await extractor.ExtractAsync(romData, asset, outputPath, new AssetsConfig());
+
+		Assert.True(result.Success);
+		Assert.True(File.Exists(outputPath));
+		var extractedData = await File.ReadAllBytesAsync(outputPath);
+		Assert.Equal(0x800, extractedData.Length); // 1 block = 2KB
+	}
+
+	public void Dispose() {
+		if (Directory.Exists(_tempDir)) {
+			try {
+				Directory.Delete(_tempDir, true);
+			} catch {
+				// Ignore cleanup errors
+			}
+		}
+	}
+}

--- a/src/GameInfoTools.Tests/GameBoyRomParserTests.cs
+++ b/src/GameInfoTools.Tests/GameBoyRomParserTests.cs
@@ -1,0 +1,486 @@
+using GameInfoTools.Core.Build;
+
+namespace GameInfoTools.Tests;
+
+/// <summary>
+/// Tests for GameBoyRomParser functionality.
+/// </summary>
+public class GameBoyRomParserTests {
+	/// <summary>
+	/// Creates a minimal valid Game Boy ROM for testing.
+	/// </summary>
+	private static byte[] CreateMinimalGameBoyRom(
+		string title = "TEST",
+		bool isCgb = false,
+		bool isSgb = false,
+		byte mbcType = 0x00,
+		byte romSizeCode = 0x00,
+		byte ramSizeCode = 0x00,
+		byte region = 0x01) {
+		// Minimum ROM size is 32KB (2 banks)
+		var romData = new byte[0x8000];
+
+		// Entry point at $100
+		romData[0x100] = 0x00; // NOP
+		romData[0x101] = 0xc3; // JP
+		romData[0x102] = 0x50; // Low byte of $0150
+		romData[0x103] = 0x01; // High byte of $0150
+
+		// Nintendo logo at $104-$133 (48 bytes)
+		var nintendoLogo = new byte[] {
+			0xce, 0xed, 0x66, 0x66, 0xcc, 0x0d, 0x00, 0x0b,
+			0x03, 0x73, 0x00, 0x83, 0x00, 0x0c, 0x00, 0x0d,
+			0x00, 0x08, 0x11, 0x1f, 0x88, 0x89, 0x00, 0x0e,
+			0xdc, 0xcc, 0x6e, 0xe6, 0xdd, 0xdd, 0xd9, 0x99,
+			0xbb, 0xbb, 0x67, 0x63, 0x6e, 0x0e, 0xec, 0xcc,
+			0xdd, 0xdc, 0x99, 0x9f, 0xbb, 0xb9, 0x33, 0x3e
+		};
+		Array.Copy(nintendoLogo, 0, romData, 0x104, nintendoLogo.Length);
+
+		// Title at $134-$143 (16 bytes for DMG, 11 for CGB)
+		var titleBytes = System.Text.Encoding.ASCII.GetBytes(title);
+		var titleLength = Math.Min(titleBytes.Length, isCgb ? 11 : 16);
+		Array.Copy(titleBytes, 0, romData, 0x134, titleLength);
+
+		// CGB flag at $143
+		if (isCgb) {
+			romData[0x143] = 0x80; // CGB compatible
+		}
+
+		// New licensee code at $144-$145
+		romData[0x144] = 0x00;
+		romData[0x145] = 0x00;
+
+		// SGB flag at $146
+		if (isSgb) {
+			romData[0x146] = 0x03; // SGB supported
+		}
+
+		// Cartridge type at $147
+		romData[0x147] = mbcType;
+
+		// ROM size at $148
+		romData[0x148] = romSizeCode;
+
+		// RAM size at $149
+		romData[0x149] = ramSizeCode;
+
+		// Destination code at $14A
+		romData[0x14A] = region;
+
+		// Old licensee code at $14B
+		romData[0x14B] = 0x33; // Use new licensee
+
+		// Mask ROM version at $14C
+		romData[0x14C] = 0x00;
+
+		// Calculate and set header checksum at $14D
+		int checksum = 0;
+		for (int i = 0x134; i <= 0x14C; i++) {
+			checksum = checksum - romData[i] - 1;
+		}
+		romData[0x14D] = (byte)(checksum & 0xff);
+
+		// Global checksum at $14E-$14F (calculated later if needed)
+		// For now, leave as zero - the parser should detect invalid checksum
+
+		return romData;
+	}
+
+	[Fact]
+	public void Constructor_WithValidRom_Succeeds() {
+		var romData = CreateMinimalGameBoyRom();
+		var parser = new GameBoyRomParser(romData);
+
+		Assert.NotNull(parser);
+	}
+
+	[Fact]
+	public void Constructor_WithNullData_ThrowsArgumentNullException() {
+		Assert.Throws<ArgumentNullException>(() => new GameBoyRomParser(null!));
+	}
+
+	[Fact]
+	public void Constructor_WithTooSmallData_StillParses() {
+		// The parser doesn't require minimum size validation -
+		// it will parse what it can from the provided data
+		var smallData = new byte[0x200]; // Small but has some header space
+		var parser = new GameBoyRomParser(smallData);
+
+		// Should parse without throwing, even with minimal data
+		var info = parser.GetRomInfo();
+		Assert.NotNull(info);
+	}
+
+	[Fact]
+	public void GetRomInfo_ReturnsCorrectTitle() {
+		var romData = CreateMinimalGameBoyRom(title: "POKEMON");
+		var parser = new GameBoyRomParser(romData);
+
+		var info = parser.GetRomInfo();
+
+		Assert.Equal("POKEMON", info.Title);
+	}
+
+	[Fact]
+	public void GetRomInfo_DetectsGameBoyColorRom() {
+		var romData = CreateMinimalGameBoyRom(isCgb: true);
+		var parser = new GameBoyRomParser(romData);
+
+		var info = parser.GetRomInfo();
+
+		Assert.True(info.IsGameBoyColor);
+	}
+
+	[Fact]
+	public void GetRomInfo_DetectsDmgOnlyRom() {
+		var romData = CreateMinimalGameBoyRom(isCgb: false);
+		var parser = new GameBoyRomParser(romData);
+
+		var info = parser.GetRomInfo();
+
+		Assert.False(info.IsGameBoyColor);
+	}
+
+	[Fact]
+	public void GetRomInfo_DetectsSuperGameBoySupport() {
+		var romData = CreateMinimalGameBoyRom(isSgb: true);
+		var parser = new GameBoyRomParser(romData);
+
+		var info = parser.GetRomInfo();
+
+		Assert.True(info.IsSuperGameBoy);
+	}
+
+	[Fact]
+	public void GetRomInfo_DetectsNoMbc() {
+		var romData = CreateMinimalGameBoyRom(mbcType: 0x00);
+		var parser = new GameBoyRomParser(romData);
+
+		var info = parser.GetRomInfo();
+
+		Assert.Equal(MbcType.None, info.MBC);
+	}
+
+	[Fact]
+	public void GetRomInfo_DetectsMbc1() {
+		var romData = CreateMinimalGameBoyRom(mbcType: 0x01);
+		var parser = new GameBoyRomParser(romData);
+
+		var info = parser.GetRomInfo();
+
+		Assert.Equal(MbcType.MBC1, info.MBC);
+	}
+
+	[Fact]
+	public void GetRomInfo_DetectsMbc1WithRam() {
+		var romData = CreateMinimalGameBoyRom(mbcType: 0x02);
+		var parser = new GameBoyRomParser(romData);
+
+		var info = parser.GetRomInfo();
+
+		Assert.Equal(MbcType.MBC1, info.MBC);
+	}
+
+	[Fact]
+	public void GetRomInfo_DetectsMbc1WithBattery() {
+		var romData = CreateMinimalGameBoyRom(mbcType: 0x03);
+		var parser = new GameBoyRomParser(romData);
+
+		var info = parser.GetRomInfo();
+
+		Assert.Equal(MbcType.MBC1, info.MBC);
+		Assert.True(info.HasBattery);
+	}
+
+	[Fact]
+	public void GetRomInfo_DetectsMbc3() {
+		var romData = CreateMinimalGameBoyRom(mbcType: 0x11);
+		var parser = new GameBoyRomParser(romData);
+
+		var info = parser.GetRomInfo();
+
+		Assert.Equal(MbcType.MBC3, info.MBC);
+	}
+
+	[Fact]
+	public void GetRomInfo_DetectsMbc3WithTimerAndBattery() {
+		var romData = CreateMinimalGameBoyRom(mbcType: 0x0F);
+		var parser = new GameBoyRomParser(romData);
+
+		var info = parser.GetRomInfo();
+
+		Assert.Equal(MbcType.MBC3, info.MBC);
+		Assert.True(info.HasTimer);
+		Assert.True(info.HasBattery);
+	}
+
+	[Fact]
+	public void GetRomInfo_DetectsMbc5() {
+		var romData = CreateMinimalGameBoyRom(mbcType: 0x19);
+		var parser = new GameBoyRomParser(romData);
+
+		var info = parser.GetRomInfo();
+
+		Assert.Equal(MbcType.MBC5, info.MBC);
+	}
+
+	[Fact]
+	public void GetRomInfo_DetectsMbc5WithRumble() {
+		var romData = CreateMinimalGameBoyRom(mbcType: 0x1C);
+		var parser = new GameBoyRomParser(romData);
+
+		var info = parser.GetRomInfo();
+
+		Assert.Equal(MbcType.MBC5, info.MBC);
+		Assert.True(info.HasRumble);
+	}
+
+	[Fact]
+	public void GetRomInfo_CalculatesRomBankCount_32KB() {
+		var romData = CreateMinimalGameBoyRom(romSizeCode: 0x00);
+		var parser = new GameBoyRomParser(romData);
+
+		var info = parser.GetRomInfo();
+
+		Assert.Equal(2, info.RomBankCount); // 32KB = 2 banks
+	}
+
+	[Fact]
+	public void GetRomInfo_CalculatesRomBankCount_64KB() {
+		var romData = CreateMinimalGameBoyRom(romSizeCode: 0x01);
+		var parser = new GameBoyRomParser(romData);
+
+		var info = parser.GetRomInfo();
+
+		Assert.Equal(4, info.RomBankCount); // 64KB = 4 banks
+	}
+
+	[Fact]
+	public void GetRomInfo_CalculatesRomBankCount_2MB() {
+		var romData = CreateMinimalGameBoyRom(romSizeCode: 0x06);
+		var parser = new GameBoyRomParser(romData);
+
+		var info = parser.GetRomInfo();
+
+		Assert.Equal(128, info.RomBankCount); // 2MB = 128 banks
+	}
+
+	[Fact]
+	public void GetRomInfo_DetectsRamSize_None() {
+		var romData = CreateMinimalGameBoyRom(ramSizeCode: 0x00);
+		var parser = new GameBoyRomParser(romData);
+
+		var info = parser.GetRomInfo();
+
+		Assert.Equal(0, info.RamBankCount);
+		Assert.Equal(0, info.RamSize);
+	}
+
+	[Fact]
+	public void GetRomInfo_DetectsRamSize_8KB() {
+		var romData = CreateMinimalGameBoyRom(ramSizeCode: 0x02);
+		var parser = new GameBoyRomParser(romData);
+
+		var info = parser.GetRomInfo();
+
+		Assert.Equal(1, info.RamBankCount); // 8KB = 1 bank
+		Assert.Equal(0x2000, info.RamSize);
+	}
+
+	[Fact]
+	public void GetRomInfo_DetectsRamSize_32KB() {
+		var romData = CreateMinimalGameBoyRom(ramSizeCode: 0x03);
+		var parser = new GameBoyRomParser(romData);
+
+		var info = parser.GetRomInfo();
+
+		Assert.Equal(4, info.RamBankCount); // 32KB = 4 banks
+		Assert.Equal(0x8000, info.RamSize);
+	}
+
+	[Fact]
+	public void GetRomInfo_DetectsJapaneseRegion() {
+		var romData = CreateMinimalGameBoyRom(region: 0x00);
+		var parser = new GameBoyRomParser(romData);
+
+		var info = parser.GetRomInfo();
+
+		Assert.Equal(GameBoyRegion.Japan, info.Region);
+	}
+
+	[Fact]
+	public void GetRomInfo_DetectsNonJapaneseRegion() {
+		var romData = CreateMinimalGameBoyRom(region: 0x01);
+		var parser = new GameBoyRomParser(romData);
+
+		var info = parser.GetRomInfo();
+
+		Assert.Equal(GameBoyRegion.Overseas, info.Region);
+	}
+
+	[Fact]
+	public void GetRomInfo_ValidatesNintendoLogo() {
+		var romData = CreateMinimalGameBoyRom();
+		var parser = new GameBoyRomParser(romData);
+
+		var info = parser.GetRomInfo();
+
+		Assert.True(info.LogoValid);
+	}
+
+	[Fact]
+	public void GetRomInfo_DetectsInvalidLogo() {
+		var romData = CreateMinimalGameBoyRom();
+		// Corrupt the logo
+		romData[0x104] = 0xFF;
+		var parser = new GameBoyRomParser(romData);
+
+		var info = parser.GetRomInfo();
+
+		Assert.False(info.LogoValid);
+	}
+
+	[Fact]
+	public void GetRomInfo_ValidatesHeaderChecksum() {
+		var romData = CreateMinimalGameBoyRom();
+		var parser = new GameBoyRomParser(romData);
+
+		var info = parser.GetRomInfo();
+
+		Assert.True(info.HeaderChecksumValid);
+	}
+
+	[Fact]
+	public void GetRomInfo_DetectsInvalidHeaderChecksum() {
+		var romData = CreateMinimalGameBoyRom();
+		// Corrupt the header checksum
+		romData[0x14D] = 0xFF;
+		var parser = new GameBoyRomParser(romData);
+
+		var info = parser.GetRomInfo();
+
+		Assert.False(info.HeaderChecksumValid);
+	}
+
+	[Fact]
+	public void RomBankCount_ReturnsCorrectCount() {
+		var romData = CreateMinimalGameBoyRom();
+		var parser = new GameBoyRomParser(romData);
+
+		Assert.Equal(2, parser.RomBankCount);
+	}
+
+	[Fact]
+	public void RomBankSize_Is16KB() {
+		Assert.Equal(0x4000, GameBoyRomParser.RomBankSize);
+	}
+
+	[Fact]
+	public void RamBankSize_Is8KB() {
+		Assert.Equal(0x2000, GameBoyRomParser.RamBankSize);
+	}
+
+	[Fact]
+	public void GetRomBank_ReturnsCorrectData() {
+		var romData = CreateMinimalGameBoyRom();
+		// Put some test data in bank 0
+		romData[0x150] = 0xAB;
+		romData[0x151] = 0xCD;
+		var parser = new GameBoyRomParser(romData);
+
+		var bank0 = parser.GetRomBank(0);
+
+		Assert.Equal(0x4000, bank0.Length);
+		Assert.Equal(0xAB, bank0[0x150]);
+		Assert.Equal(0xCD, bank0[0x151]);
+	}
+
+	[Fact]
+	public void GetRomBank_ReturnsBank1Data() {
+		var romData = CreateMinimalGameBoyRom();
+		// Put some test data in bank 1
+		romData[0x4000] = 0x12;
+		romData[0x4001] = 0x34;
+		var parser = new GameBoyRomParser(romData);
+
+		var bank1 = parser.GetRomBank(1);
+
+		Assert.Equal(0x4000, bank1.Length);
+		Assert.Equal(0x12, bank1[0]);
+		Assert.Equal(0x34, bank1[1]);
+	}
+
+	[Fact]
+	public void GetRomBank_WithInvalidIndex_ThrowsArgumentOutOfRangeException() {
+		var romData = CreateMinimalGameBoyRom();
+		var parser = new GameBoyRomParser(romData);
+
+		Assert.Throws<ArgumentOutOfRangeException>(() => parser.GetRomBank(99));
+	}
+
+	[Fact]
+	public void CalculateHeaderChecksum_ReturnsCorrectValue() {
+		var romData = CreateMinimalGameBoyRom();
+		var parser = new GameBoyRomParser(romData);
+
+		var calculatedChecksum = parser.CalculateHeaderChecksum();
+		var storedChecksum = romData[0x14D];
+
+		Assert.Equal(storedChecksum, calculatedChecksum);
+	}
+
+	[Fact]
+	public void FixHeaderChecksum_CorrectsBadChecksum() {
+		var romData = CreateMinimalGameBoyRom();
+		// Corrupt the header checksum
+		romData[0x14D] = 0x00;
+
+		var fixedRom = GameBoyRomParser.FixHeaderChecksum(romData);
+
+		// Verify the checksum is now valid
+		var fixedParser = new GameBoyRomParser(fixedRom);
+		var info = fixedParser.GetRomInfo();
+		Assert.True(info.HeaderChecksumValid);
+	}
+
+	[Fact]
+	public void GetRomInfo_DetectsMbc2() {
+		var romData = CreateMinimalGameBoyRom(mbcType: 0x05);
+		var parser = new GameBoyRomParser(romData);
+
+		var info = parser.GetRomInfo();
+
+		Assert.Equal(MbcType.MBC2, info.MBC);
+	}
+
+	[Fact]
+	public void GetRomInfo_DetectsHuC1() {
+		var romData = CreateMinimalGameBoyRom(mbcType: 0xFF);
+		var parser = new GameBoyRomParser(romData);
+
+		var info = parser.GetRomInfo();
+
+		Assert.Equal(MbcType.HuC1, info.MBC);
+	}
+
+	[Fact]
+	public void GetRomInfo_DetectsHuC3() {
+		var romData = CreateMinimalGameBoyRom(mbcType: 0xFE);
+		var parser = new GameBoyRomParser(romData);
+
+		var info = parser.GetRomInfo();
+
+		Assert.Equal(MbcType.HuC3, info.MBC);
+	}
+
+	[Fact]
+	public void GetRomInfo_DetectsPocketCamera() {
+		var romData = CreateMinimalGameBoyRom(mbcType: 0xFC);
+		var parser = new GameBoyRomParser(romData);
+
+		var info = parser.GetRomInfo();
+
+		Assert.Equal(MbcType.PocketCamera, info.MBC);
+	}
+}


### PR DESCRIPTION
Implements the Game Boy / Game Boy Color Build Pipeline (Issue #60).

## Changes
- GameBoyRomParser.cs (~510 lines): GB/GBC ROM header parsing, MBC detection, bank extraction, checksum validation
- GameBoyAssetExtractor.cs (~386 lines): Bank/tile/palette extraction
- 88 new tests (53 parser + 10 extractor tests)

Closes #60